### PR TITLE
fix issue #1

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,7 +28,7 @@ jobs:
             cxx: msvc
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Configure CMake
         env:
@@ -55,7 +55,7 @@ jobs:
         run: cmake --install . --config $BUILD_TYPE
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wx-widgets-test_build_${{ github.run_number }}_${{ matrix.platform_name }}
           path: ${{github.workspace}}/artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,6 +1,8 @@
 name: build-release
 
 on:
+  workflow_dispatch:
+  
   release:
     types: [published]
 
@@ -15,14 +17,14 @@ jobs:
         # specify a specific compiler to build with each OS separately
         include:
           - platform_name: linux
-            os: ubuntu-20.04
-            cxx: g++-10
+            os: ubuntu-latest
+            cxx: g++
           - platform_name: macos
-            os: macos-10.15
+            os: macos-latest
             cxx: clang++
           # NOTE: CXX seems to be ignored on Windows, but specify it anyway for consistency
           - platform_name: windows
-            os: windows-2019
+            os: windows-latest
             cxx: msvc
 
     steps:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Linux Dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libgtk-3-dev libglew-dev
+
       - name: Configure CMake
         env:
           CXX: ${{ matrix.cxx }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,16 +18,16 @@ jobs:
         # specify a specific compiler to build with each OS separately
         include:
           - platform_name: linux
-            os: ubuntu-20.04
+            os: ubuntu-latest
             cxx: g++-10
             cmake_generator: "Unix Makefiles"
           - platform_name: macos
-            os: macos-10.15
+            os: macos-latest
             cxx: clang++
             cmake_generator: "Unix Makefiles"
           # NOTE: CXX seems to be ignored on Windows, but specify it anyway for consistency
           - platform_name: windows
-            os: windows-2019
+            os: windows-latest
             cxx: msvc
             cmake_generator: ""
 
@@ -53,7 +53,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache CMake dependency build objects
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-cmake-dependency-builds
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt-get install libgtk-3-dev libglew-dev
 
       - name: Cache CMake dependency source code
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-cmake-dependency-sources
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - platform_name: linux
             os: ubuntu-latest
-            cxx: g++-10
+            cxx: g++
             cmake_generator: "Unix Makefiles"
           - platform_name: macos
             os: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # begin basic metadata
 # minimum CMake version required for C++20 support, among other things
+
 cmake_minimum_required(VERSION 3.15)
 
 # detect if MyHovercraftIsFullOfEels is being used as a sub-project of another CMake project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 # begin basic metadata
 # minimum CMake version required for C++20 support, among other things
-
 cmake_minimum_required(VERSION 3.15)
 
 # detect if MyHovercraftIsFullOfEels is being used as a sub-project of another CMake project


### PR DESCRIPTION
continuous-integration action runs. 

build-release action runs on Linux and MacOS, but does not upload any artifact, since the upload artifact path is not specified correctly. Windows release build fails with linker error unresolved symbols. 